### PR TITLE
use XDG_STATE_HOME instead of XDG_LOG_HOME

### DIFF
--- a/README.org
+++ b/README.org
@@ -58,7 +58,7 @@ herd stop dtao-guile
 herd restart dtao-guile
 #+end_src
 
-Logs are available at =$XDG_LOG_HOME/dtao-guile.log= (logs will be saved to your home directory if =$XDG_LOG_HOME= is not set).
+Logs are available at =$XDG_STATE_HOME/log/dtao-guile.log= (logs will be saved to =$HOME/.local/state/log/dtao-guile.log= if =$XDG_STATE_HOME= is not set).
 
 *** Configuring =dtao-guile=
 

--- a/dtao-guile/home-service.scm
+++ b/dtao-guile/home-service.scm
@@ -110,8 +110,10 @@
            #$(file-append (home-dtao-guile-configuration-package config) "/bin/dtao-guile")
            "-c" #$(string-append config-dir "/config.scm"))
           #:user (getenv "USER")
-          #:log-file #$(string-append (or (getenv "XDG_LOG_HOME") (getenv "HOME"))
-                                      "/dtao-guile.log"))))
+          #:log-file #$(format #f "~a/log/dtao-guile.log"
+                           (or (getenv "XDG_STATE_HOME")
+                               (format #f "~a/.local/state"
+                                       (getenv "HOME")))))))
     (stop #~(make-kill-destructor)))))
 
 (define (home-dtao-guile-extensions cfg extensions)


### PR DESCRIPTION
Moves logfile to XDG_STATE_HOME/log/dtao-guile.log

See https://wiki.debian.org/XDGBaseDirectorySpecification